### PR TITLE
gx publish 0.1.3

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.2: QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh
+0.1.3: QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg

--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB",
+      "hash": "QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS",
       "name": "go-cid",
-      "version": "0.7.16"
+      "version": "0.7.17"
     },
     {
       "author": "multiformats",
-      "hash": "QmVGtdTZdTFaLsaj2RwdVG8jcjNNcp1DE914DKZ2kHmXHw",
+      "hash": "QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P",
       "name": "go-multihash",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWbjfz3u6HkAdPh34dgPchGbQjob6LXLhAeCGii2TX69n",
+      "hash": "QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU",
       "name": "go-ipfs-util",
-      "version": "1.2.4"
+      "version": "1.2.5"
     }
   ],
   "gxVersion": "0.11.0",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-block-format",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }
 


### PR DESCRIPTION
Updates go-multihash and go-cid to allow for identity hashes.