### PR TITLE
use go-cid v 0.7.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmapdYm1b22Frv3k17fqrBYTFRxwiaVJkB299Mfn33edeB",
+      "hash": "QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP",
       "name": "go-cid",
-      "version": "0.7.21"
+      "version": "0.7.22"
     },
     {
       "author": "multiformats",


### PR DESCRIPTION
This propagates a bugfix in service of https://github.com/filecoin-project/go-filecoin/issues/626.